### PR TITLE
Code si countdown est vide 

### DIFF
--- a/check.py
+++ b/check.py
@@ -1,0 +1,13 @@
+import os
+
+def fileSize():
+	countfile = "countdown.txt"
+	if os.stat(countfile).st_size == 0:
+		print ("empty")
+		count = open("countdown.txt", "w+")
+		count.write(str(0))
+		count.close()	
+		print("counting n'est plus vide")
+	else:
+		print("counting n'est pas vide, keep going")
+	

--- a/printing.py
+++ b/printing.py
@@ -1,5 +1,7 @@
 from escpos.printer import Usb # import Usb class
+import os
 import random_article
+import check
 from PIL import Image
 
 # the number of prints before it prints a coupon is setup here
@@ -28,6 +30,8 @@ def counting():
 # Function that prints a selected article when it is called;
 # uses random_article.py and its selectRandomArticle function to pick a random article
 def printFile():
+	# On vérifie si countdown est vide ou non et s'il l'est, on le remet à 0
+	check.fileSize()
 	
 	# RANDOM PRINTING
 	article = random_article.selectRandomArticle()

--- a/random_article.py
+++ b/random_article.py
@@ -32,7 +32,7 @@ def selectRandomArticle():
 	
 	# Pour gérer quand on retourne un article météo ou un article normal, on ouvre le fichier countdown.txt
 	countdown = open("countdown.txt") 
-	
+
 	# et on le lit
 	for line in countdown:
 		count = int(line) # on récupère le chiffre (qui est en str) et on le transforme en int pour le sauvegarder dans count
@@ -61,3 +61,4 @@ def selectRandomArticle():
 			selectedArticle = printableArticles[randomIndex] # et on utilise ce nombre aléatoire comme index pour récupérer un article
 			print("count % n != 0 donc voici un article général : "+selectedArticle)
 			return selectedArticle # on retourne un article général
+	countdown.close()


### PR DESCRIPTION
Parfois countown.txt est vide ce qui empêche l'impression des articles. Solution pour vérifier si countdown est vide ou non avant l'impression d'un fichier en écrivant 0. 